### PR TITLE
Update version constraints, fix NumPy depr, suppress Pandas warning & prepare v0.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Sindri Changelog
 
 
+## Version 0.2.11 (2021-05-31)
+
+Maintenance release with the following changes:
+
+* Fix null values not being handled properly in JSON on recent pandas versions
+* Use relative links in archive table to fix breakage when not at the site root
+* Fix NumPy deprecations and handle pandas deprecation warning
+* Add/update version constraints in dependency requirements
+* Add missing Sindri 0.2.10 release in Changelog
+
+
+
 ## Version 0.2.10 (2021-09-07)
 
 Maintenance release with the following changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Sindri Changelog
 
 
+## Version 0.2.10 (2021-09-07)
+
+Maintenance release with the following changes:
+
+* Re-order plot sections to match usage
+* Modify color coding and thresholds to preferred values
+
+
+
 ## Version 0.2.9 (2020-10-23)
 
 Maintenance release with the following changes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-lektor>=3.1
-numpy
-pandas
-serviceinstaller>=0.1.1; sys_platform == 'linux'
+jinja2>=2,<3
+lektor>=3.1.3,<4
+MarkupSafe>=1,<2
+numpy>=1,<2
+pandas>=1,<2

--- a/setup.py
+++ b/setup.py
@@ -69,9 +69,12 @@ setuptools.setup(
         },
     python_requires=">=3.6",
     install_requires=[
-        "lektor>=3.1",
-        "numpy",
-        "pandas",
+        "jinja2>=2,<3",
+        "lektor>=3.1.3,<4",
+        "MarkupSafe>=1,<2",
+        "numpy>=1,<2",
+        "pandas>=1,<2",
+        "serviceinstaller>=0.1.4; sys_platform == 'linux'",
         ],
     entry_points={
         "console_scripts": [

--- a/src/sindri/_version.py
+++ b/src/sindri/_version.py
@@ -1,4 +1,4 @@
 """Version file."""
 
-VERSION_INFO = (0, 2, 10)
+VERSION_INFO = (0, 2, 11)
 __version__ = '.'.join((str(version) for version in VERSION_INFO))

--- a/src/sindri/process.py
+++ b/src/sindri/process.py
@@ -4,6 +4,7 @@ Basic processing code for HAMMA Mjolnir data.
 """
 
 # Standard library imports
+import warnings
 from pathlib import Path
 
 # Third party imports
@@ -78,9 +79,12 @@ def load_status_data(n_days=None, lag=None, data_dir=DATA_DIR_DEFAULT,
                      glob_pattern=GLOB_PATTERN_DEFAULT):
     files_to_load = get_status_data_paths(
         n_days=n_days, lag=lag, data_dir=data_dir, glob_pattern=glob_pattern)
-    status_data = pd.concat(
-        (pd.read_csv(file, error_bad_lines=False) for file in files_to_load),
-        ignore_index=True, sort=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        status_data = pd.concat(
+            (pd.read_csv(file, error_bad_lines=False)
+             for file in files_to_load),
+            ignore_index=True, sort=False)
     return status_data
 
 

--- a/src/sindri/website/generate.py
+++ b/src/sindri/website/generate.py
@@ -70,10 +70,10 @@ class CustomJSONEncoder(json.JSONEncoder):
             return int(obj)
         if isinstance(obj, np.floating):
             return float(obj)
-        if isinstance(obj, (np.bool, np.bool_)):
+        if isinstance(obj, np.bool_):
             return bool(obj)
         if isinstance(obj, np.ndarray):
-            return obj.to_list()
+            return obj.tolist()
         return json.JSONEncoder.default(self, obj)
 
 


### PR DESCRIPTION
We should cut one more release in the 0.2.x branch with the additional unreleased but deployed fixes. In addition, I backported the most critical fixes from the 0.3.x branch: updating the version constraints to ensure we get working versions of dependencies, updating a couple deprecated or flat-out-incorrect NumPy constructs, and suppressing (until 0.3.0, where it is already fixed) the Pandas deprecation warning for `error_bad_lines`.

I've tested everything already locally, on the Pis and server, so I'll merge this and then execute the release.

Fix #14 